### PR TITLE
fix(api): Handle CORS pre-flight OPTIONS requests

### DIFF
--- a/auth-server/handler.js
+++ b/auth-server/handler.js
@@ -81,6 +81,19 @@ module.exports.getAccessToken = async (event) => {
 // --- Start of new code for STEP 3: INTERGRATE THE ACCESS TOKEN IN YOUR NEW getCalendarEvents() Function. ---
 module.exports.getCalendarEvents = async (event) => {
 
+  // --- FIX: ADDED THIS BLOCK TO HANDLE PRE-FLIGHT OPTIONS REQUESTS ---
+  if(event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      },
+    };
+  }
+  // --- END OF FIX ---
+
   // The access_token will be passed in the path parameter
   // Get the access_token from the parameter
   const access_token = decodeURIComponent(event.pathParameters.access_token);


### PR DESCRIPTION
Resolves persistent "Failed to fetch" errors by correctly handling the CORS pre-flight handshake.

After deploying an initial fix, Atatus monitoring showed the error was still occurring. The root cause was identified as the API not responding to the browser's preliminary `OPTIONS` request, which is required before the actual `GET` request can be sent for cross-origin calls.

This commit adds logic at the beginning of the `getCalendarEvents` function to detect an `httpMethod` of `OPTIONS` and immediately return a 200 OK response with the necessary `Access-Control-Allow-*` headers. This gives the browser the required permission to proceed with the actual data request, finally resolving the issue.