### PR TITLE
feat(pwa): Implement offline data caching for events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "atatus-spa": "^4.6.5",
+        "nprogress": "^0.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "vite-plugin-pwa": "^1.0.2",
@@ -9541,6 +9542,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/nprogress": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
+      "license": "MIT"
     },
     "node_modules/nwsapi": {
       "version": "2.2.20",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "atatus-spa": "^4.6.5",
+    "nprogress": "^0.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "vite-plugin-pwa": "^1.0.2",

--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,5 @@
 /* src/App.css */
+@import 'nprogress/nprogress.css';
 
 /* --- General App & Layout Styles --- */
 body {

--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,7 @@
 // src/api.js
 
 import mockData from './mock-data';
+import NProgress from 'nprogress';
 
 export const extractLocations = (events) => {
     const extractedLocations = events.map((event) => event.location);
@@ -68,6 +69,17 @@ export const getEvents = async () => {
         return mockData;
     }
 
+
+    // --- START OF NEW/MODIFIED LOGIC ---
+    NProgress.start();
+
+    // If the user is offline, load event data from localStorage.
+    if (!navigator.onLine) {
+        const events = localStorage.getItem("lastEvents");
+        NProgress.done();
+        return events ? JSON.parse(events) : [];
+    }
+
     const token = await getAccessToken();
 
     if (token) {
@@ -76,10 +88,15 @@ export const getEvents = async () => {
         const response = await fetch(url);
         const result = await response.json();
         if (result) {
+            NProgress.done();
+            // Save fetched events to localStorage when online.
+            localStorage.setItem("lastEvents", JSON.stringify(result.events));
             return result.events;
         } else {
+            NProgress.done();
             return null;
         }
     }
+    NProgress.done();
     return null;
 };


### PR DESCRIPTION
This commit enhances the PWA's offline functionality by caching the event list data in the browser's localStorage.

- The `getEvents` function in `api.js` now uses `navigator.onLine` to check the connection status.
- When online, the app fetches events from the API and saves a copy to localStorage.
- When offline, the app retrieves and displays the last-known event list from localStorage.
- Adds `NProgress` to provide visual feedback to the user during the data fetching process.